### PR TITLE
Make compatible w/ older versions of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, true));
 
 ## Requirements
 
-* Node v4.2 or above
+* Node v0.10.32 or above
 * Express 4 or above
 
 ## Testing

--- a/index.js
+++ b/index.js
@@ -1,30 +1,30 @@
 'use strict'
 
-const fs = require('fs');
-const express = require('express');
+var fs = require('fs');
+var express = require('express');
 
-const explorerHtml = `<form id='api_selector'>
-                        <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-                        <div id='auth_container'></div>
-                        <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
-                      </form>`
+var explorerHtml = '<form id="api_selector">'+
+                        '<div class="input"><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>' +
+                        '<div id="auth_container"></div>' +
+                        '<div class="input"><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>' +
+                      '</form>';
 
-const setup = (swaggerDoc, explorer) => {
-	const html = fs.readFileSync(__dirname + '/indexTemplate.html');
+var setup = function(swaggerDoc, explorer) {
+	var html = fs.readFileSync(__dirname + '/indexTemplate.html');
     try {
     	fs.unlinkSync(__dirname + '/index.html');
     } catch (e) {
 
     }
-    const htmlWithSwaggerReplaced = html.toString().replace('<% swaggerDoc %>', JSON.stringify(swaggerDoc));
-    const explorerString = explorer ?  explorerHtml : '';
-    const indexHTML = htmlWithSwaggerReplaced.replace('<% explorerString %>', explorerString)
-    return (req, res) => res.send(indexHTML);
-}
+    var htmlWithSwaggerReplaced = html.toString().replace('<% swaggerDoc %>', JSON.stringify(swaggerDoc));
+    var explorerString = explorer ?  explorerHtml : '';
+    var indexHTML = htmlWithSwaggerReplaced.replace('<% explorerString %>', explorerString)
+    return function(req, res) { res.send(indexHTML) };
+};
 
-const serve = express.static(__dirname + '/static')
+var serve = express.static(__dirname + '/static')
 
 module.exports = {
-	setup,
-	serve
+	setup: setup,
+	serve: serve
 };

--- a/package.json
+++ b/package.json
@@ -13,24 +13,25 @@
     "test": "./node_modules/.bin/mocha test/*"
   },
   "keywords": [
-		"swagger",
-		"express",
-		"ui",
-		"json",
-		"documentation"
+    "swagger",
+    "express",
+    "ui",
+    "json",
+    "documentation"
   ],
   "private": false,
   "engines": {
-    "node": ">= 4.2.0"
+    "node": ">= v0.10.32"
   },
   "devDependencies": {
-		"mocha": "2.2.5",
-		"express": "4.12.2",
-		"phantom": "2.1.21"
-	},
+    "es6-shim": "0.35.2",
+    "express": "4.12.2",
+    "mocha": "2.2.5",
+    "phantom": "2.1.21"
+  },
   "author": {
     "name": "Stephen Scott",
-		"email": "scottie1984@gmail.com"
+    "email": "scottie1984@gmail.com"
   },
   "repository": {
     "type": "git",

--- a/test/testapp/app.js
+++ b/test/testapp/app.js
@@ -1,11 +1,11 @@
-const express = require('express');
-const app = express();
-const swaggerUi = require('../../index');
-const swaggerDocument = require('./swagger.json');
+var express = require('express');
+var app = express();
+var swaggerUi = require('../../index');
+var swaggerDocument = require('./swagger.json');
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
-app.get('/', (req, res) => res.json({ status: 'OK'}))
-app.get('/bar', (req, res) => res.json({ status: 'OKISH'}))
+app.get('/', function(req, res) { res.json({ status: 'OK'}); });
+app.get('/bar', function(req, res) { res.json({ status: 'OKISH'}); });
 
 module.exports = app;

--- a/test/testapp/run.js
+++ b/test/testapp/run.js
@@ -1,5 +1,5 @@
-const app = require('./app');
+var app = require('./app');
 
-app.listen(3000, function () {
+app.listen(3000, function() {
   console.log('Example app listening on port 3000!')
 })


### PR DESCRIPTION
I found myself in a position where I wanted to use this library, but wasn't able to update the version of node running the app. The version the server is running is v0.10.32 (pretty old) and doesn't support fat-arrow functions, const, etc. Here is the code if you  are interested in including it to reach others in the same position.

Additionally, I modified the tests so that they are passing now and confirm the UI elements are present as expected.