### PR TITLE
Support specify OAuth parameters via options.oauth

### DIFF
--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -97,6 +97,10 @@ window.onload = function() {
   }
   var ui = SwaggerUIBundle(swaggerOptions)
 
+  if (customOptions.oauth) {
+    ui.initOAuth(customOptions.oauth)
+  }
+
   window.ui = ui
 }
 </script>


### PR DESCRIPTION
This is the PR that containing my code to support setting OAuth parameters that are available in swagger-ui (see https://github.com/swagger-api/swagger-ui), which is based on the idea mentioned in #5 