### PR TITLE
Add `swaggerUrl` to setup function, as alternative to `swaggerDoc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ var customCss = '#header { display: none }';
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, showExplorer, options, customCss));
 ```
 
+### Load swagger from url
+
+To load your swagger from a url instead of injecting the document, pass `null` as the first parameter, and pass the relative or absolute URL as the sixth parameter.
+
+```javascript
+const express = require('express');
+const app = express();
+const swaggerUi = require('swagger-ui-express');
+
+const swaggerDocument = require('./swagger.json');
+
+app.static
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(null, null, null, null, null, 'http://petstore.swagger.io/v2/swagger.json'));
+```
+
 ## Requirements
 
 * Node v0.10.32 or above

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var favIconHtml = '<link rel="icon" type="image/png" href="./favicon-32x32.png" 
                   '<link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />'
 
 
-var setup = function(swaggerDoc, explorer, options, customCss, customfavIcon) {
+var setup = function(swaggerDoc, explorer, options, customCss, customfavIcon, swaggerUrl) {
 	options = options || {};
   var explorerString = explorer ?  '' : '.swagger-ui .topbar .download-url-wrapper { display: none }';
     customCss = explorerString + ' ' + customCss || explorerString;
@@ -18,13 +18,14 @@ var setup = function(swaggerDoc, explorer, options, customCss, customfavIcon) {
     } catch (e) {
 
     }
-    var htmlWithSwaggerReplaced = html.toString().replace('<% swaggerDoc %>', JSON.stringify(swaggerDoc));
+    var htmlWithSwaggerReplaced = html.toString().replace('<% swaggerDoc %>', swaggerDoc ? JSON.stringify(swaggerDoc) : 'undefined');
     var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml;
     var indexHTML = htmlWithSwaggerReplaced.replace('<% customOptions %>', stringify(options))
     var htmlWithCustomCss  = indexHTML.replace('<% customCss %>', customCss);
     var htmlWithFavIcon  = htmlWithCustomCss.replace('<% favIconString %>', favIconString);
+    var htmlWithSwaggerUrl = htmlWithFavIcon.replace('<% swaggerUrl %>', swaggerUrl ? '"' + swaggerUrl + '"' : 'undefined')
 
-    return function(req, res) { res.send(htmlWithFavIcon) };
+    return function(req, res) { res.send(htmlWithSwaggerUrl) };
 };
 
 var serve = express.static(__dirname + '/static');

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -77,6 +77,7 @@ window.onload = function() {
   } else {
     url = window.location.origin;
   }
+  url = <% swaggerUrl %> || url
   var customOptions = <% customOptions %>
   var spec1 = <% swaggerDoc %>
   var swaggerOptions = {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -24,7 +24,7 @@ describe('integration', function() {
 	});
 
 	it('should have API Documentation hosted at /api-docs', function(done) {
-    this.timeout(5000);
+    this.timeout(30000);
     phantom.create()
       .then(function(instance) {
         phInstance = instance;
@@ -39,11 +39,13 @@ describe('integration', function() {
           assert.equal('success', status);
           done();
         }, 100);
+      })
+      .catch(function(err) {
+        done(err);
       });
   });
 
   it('should contain the expected elements on the page', function(done) {
-    this.timeout(5000);
     sitepage.property('title')
       .then(function(title) {
         assert.equal('Swagger UI', title);
@@ -53,9 +55,44 @@ describe('integration', function() {
       })
       .then(function(html) {
         assert.ok(html);
-        assert.notEqual(html.indexOf('id="operations,get-/,/test"'), -1);
-        assert.notEqual(html.indexOf('id="operations,get-/bar,/test"'), -1);
+        assert.notEqual(html.indexOf('id="operations-/test-index"'), -1);
+        assert.notEqual(html.indexOf('id="operations-/test-impossible"'), -1);
         done();
+      })
+      .catch(function(err) {
+        done(err);
       });
 	});
+
+  it('should have API Documentation hosted at /api-docs-from-url', function(done) {
+    sitepage.open('http://localhost:3001/api-docs-from-url/')
+      .then(function(status) {
+        setTimeout(function() {
+          assert.equal('success', status);
+          done();
+        }, 100);
+      })
+      .catch(function(err) {
+        done(err);
+      });
+  });
+
+  it('should contain the expected elements on the page', function(done) {
+    sitepage.property('title')
+      .then(function(title) {
+        assert.equal('Swagger UI', title);
+        return sitepage.evaluate(function() {
+          return document.querySelector('.swagger-ui').innerHTML;
+        });
+      })
+      .then(function(html) {
+        assert.ok(html);
+        assert.notEqual(html.indexOf('id="operations-/test-index"'), -1);
+        assert.notEqual(html.indexOf('id="operations-/test-impossible"'), -1);
+        done();
+      })
+      .catch(function(err) {
+        done(err);
+      });
+  });
 });

--- a/test/testapp/app.js
+++ b/test/testapp/app.js
@@ -32,6 +32,9 @@ app.get('/bar', function(req, res) { res.json({ status: 'OKISH'}); });
 app.use('/api-docs', swaggerUi.serve)
 app.get('/api-docs', swaggerUi.setup(swaggerDocument, false, options, '.swagger-ui .topbar { background-color: red }'));
 
+app.use('/api-docs-from-url', swaggerUi.serve)
+app.get('/api-docs-from-url', swaggerUi.setup(null, false, options, '.swagger-ui .topbar { background-color: red }', null, '/swagger.json'));
+
 app.use(function(req, res) {
     res.send(404, 'Page not found');
 });


### PR DESCRIPTION
Following up on #20, this PR adds the `swaggerUrl` option to the `setup` function.

This allows things like:

1. Allowing relative `$ref` paths if your swagger is split into multiple files
1. Showing the link to the swagger definition in the UI without having to specify the path in the URL query string
1. Checking your swagger against the online validator (if it's accessible to the open internet)

I wanted to get this up here to get feedback, but I still have to:

1. Get the tests running, I've tested the changes manually but I'm having some trouble getting the automated tests to pass, so I'll take another shot at that tomorrow
1. Update the README