### PR TITLE
Serve swagger-ui-init as a static file so works when unsafe-inline is…

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,19 @@ var setup = function(swaggerDoc, explorer, options, customCss, customfavIcon, sw
     } catch (e) {
 
     }
-    var htmlWithSwaggerReplaced = html.toString().replace('<% swaggerDoc %>', swaggerDoc ? JSON.stringify(swaggerDoc) : 'undefined');
-    var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml;
-    var indexHTML = htmlWithSwaggerReplaced.replace('<% customOptions %>', stringify(options))
-    var htmlWithCustomCss  = indexHTML.replace('<% customCss %>', customCss);
-    var htmlWithFavIcon  = htmlWithCustomCss.replace('<% favIconString %>', favIconString);
-    var htmlWithSwaggerUrl = htmlWithFavIcon.replace('<% swaggerUrl %>', swaggerUrl ? '"' + swaggerUrl + '"' : 'undefined')
 
-    return function(req, res) { res.send(htmlWithSwaggerUrl) };
+    var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml;
+    var htmlWithCustomCss  = html.toString().replace('<% customCss %>', customCss);
+    var htmlWithFavIcon  = htmlWithCustomCss.replace('<% favIconString %>', favIconString);
+
+    var initOptions = {
+      swaggerDoc: swaggerDoc || undefined,
+      customOptions: options,
+      swaggerUrl: swaggerUrl || undefined
+    }
+    var htmlWithOptions = htmlWithFavIcon.replace('<% swaggerOptions %>', JSON.stringify(initOptions))
+
+    return function(req, res) { res.send(htmlWithOptions) };
 };
 
 var serve = express.static(__dirname + '/static');

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -65,46 +65,11 @@
 </svg>
 
 <div id="swagger-ui"></div>
+<div id="swagger-options" style="display:none"><% swaggerOptions %></div>
 
 <script src="./swagger-ui-bundle.js"> </script>
 <script src="./swagger-ui-standalone-preset.js"> </script>
-<script>
-window.onload = function() {
-  // Build a system
-  var url = window.location.search.match(/url=([^&]+)/);
-  if (url && url.length > 1) {
-    url = decodeURIComponent(url[1]);
-  } else {
-    url = window.location.origin;
-  }
-  url = <% swaggerUrl %> || url
-  var customOptions = <% customOptions %>
-  var spec1 = <% swaggerDoc %>
-  var swaggerOptions = {
-    spec: spec1,
-    url: url,
-    dom_id: '#swagger-ui',
-    presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
-    ],
-    plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
-    ],
-    layout: "StandaloneLayout"
-  }
-  for (var attrname in customOptions) {
-    swaggerOptions[attrname] = customOptions[attrname];
-  }
-  var ui = SwaggerUIBundle(swaggerOptions)
-
-  if (customOptions.oauth) {
-    ui.initOAuth(customOptions.oauth)
-  }
-
-  window.ui = ui
-}
-</script>
+<script src="./swagger-ui-init.js"> </script>
 <style>
 <% customCss %>
 </style>

--- a/static/swagger-ui-init.js
+++ b/static/swagger-ui-init.js
@@ -1,0 +1,37 @@
+
+window.onload = function() {
+  // Build a system
+  var url = window.location.search.match(/url=([^&]+)/);
+  if (url && url.length > 1) {
+    url = decodeURIComponent(url[1]);
+  } else {
+    url = window.location.origin;
+  }
+  var options = JSON.parse(document.getElementById('swagger-options').innerText)
+  url = options.swaggerUrl || url
+  var customOptions = options.customOptions
+  var spec1 = options.swaggerDoc
+  var swaggerOptions = {
+    spec: spec1,
+    url: url,
+    dom_id: '#swagger-ui',
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ],
+    layout: "StandaloneLayout"
+  }
+  for (var attrname in customOptions) {
+    swaggerOptions[attrname] = customOptions[attrname];
+  }
+  var ui = SwaggerUIBundle(swaggerOptions)
+
+  if (customOptions.oauth) {
+    ui.initOAuth(customOptions.oauth)
+  }
+
+  window.ui = ui
+}


### PR DESCRIPTION
… blocked

Fixes https://github.com/scottie1984/swagger-ui-express/issues/24

Tried to serve a templated js file, but per the tests swaggerUi.setup was only being used with a GET which didn't allow serving up separate files as typical middleware might. Based on that this pushes the options into a hidden div on the page which are then parsed by the swagger-ui-init file served via the express.static call.