### PR TITLE
Make it possible to have CSP without 'unsafe-inline’

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ var options = {
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
 ```
 
+### Avoiding unsafe-inline with Content-Security-Policy
+
+If you are using CSP and want to avoid adding 'unsafe-inline' to your 'style-src', you can specify a nonce to be used by setting `res.locals.nonce`, and adding the nonce to the CSP policy.
 
 ### Custom JS
 

--- a/index.js
+++ b/index.js
@@ -50,9 +50,15 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
     return htmlWithCustomJs.replace('<% title %>', customeSiteTitle)
 }
 
+var replaceNonce = function(html, nonce) {
+  return html.replace('<% nonce %>', nonce || '').replace('<% nonce %>', nonce || '');
+}
+
 var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-    var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-    return function (req, res) { res.send(htmlWithOptions) };
+    var html = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
+    return function (req, res) {
+      res.send(replaceNonce(html, res.locals.nonce));
+    };
 };
 
 function swaggerInitFn (req, res, next) {
@@ -111,6 +117,10 @@ module.exports = {
 	setup: setup,
 	serve: serve,
   serveWithOptions: serveWithOptions,
-  generateHTML: generateHTML,
+  generateHTML: function() {
+    var html = generateHTML.call(null, arguments);
+
+    return replaceNonce(html);
+  },
   serveFiles: serveFiles
 };

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <% favIconString %>
   <% customJs %>
-  <style>
+  <style nonce="<% nonce %>">
     html
     {
         box-sizing: border-box;
@@ -26,12 +26,18 @@
       margin:0;
       background: #fafafa;
     }
+
+    .svgs {
+       position: absolute;
+       width:0;
+       height:0
+    }
   </style>
 </head>
 
 <body>
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="svgs">
   <defs>
     <symbol viewBox="0 0 20 20" id="unlocked">
           <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
@@ -70,7 +76,7 @@
 <script src="./swagger-ui-bundle.js"> </script>
 <script src="./swagger-ui-standalone-preset.js"> </script>
 <script src="./swagger-ui-init.js"> </script>
-<style>
+<style nonce="<% nonce %>">
 <% customCss %>
 </style>
 </body>


### PR DESCRIPTION
This adds support for having a Content-Security-Policy without 'unsafe-inline' for 'style-src'. It is a bit hackish I think, but it was the simplest way I could think of doing it.