### PR TITLE
Don't load the Google Web Fonts CSS anymore

### DIFF
--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="UTF-8">
   <title><% title %></title>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <% favIconString %>
   <% customJs %>


### PR DESCRIPTION
swagger-ui 3.17.3 included https://github.com/swagger-api/swagger-ui/pull/4598, which stopped using Google Web Fonts, so it's no longer necessary to load the Google Web Fonts CSS.

For the record there's still [one accidental reference left](https://github.com/swagger-api/swagger-ui/pull/4840), but that will just fall back to `sans-serif` if nothing is providing the font via a `@font-face` declaration. So this PR isn't really blocked on the other one.