### PR TITLE
Support for the url parameter of the swagger-ui library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "8"
+  - "10"
+script:
+ - npm test

--- a/index.js
+++ b/index.js
@@ -12,13 +12,15 @@ var swaggerInit
 var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
   var isExplorer
   var customJs
+  var swaggerUrls
   if (opts && typeof opts === 'object') {
-    isExplorer = opts.explorer
     options = opts.swaggerOptions
     customCss = opts.customCss
     customJs = opts.customJs
     customfavIcon = opts.customfavIcon
     swaggerUrl = opts.swaggerUrl
+    swaggerUrls = opts.swaggerUrls
+    isExplorer = opts.explorer || !!swaggerUrls
     customeSiteTitle = opts.customSiteTitle
   } else {
     //support legacy params based function
@@ -44,7 +46,8 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
     var initOptions = {
       swaggerDoc: swaggerDoc || undefined,
       customOptions: options,
-      swaggerUrl: swaggerUrl || undefined
+      swaggerUrl: swaggerUrl || undefined,
+      swaggerUrls: swaggerUrls || undefined
     }
     var js = fs.readFileSync(__dirname + '/swagger-ui-init.js');
     swaggerInit = js.toString().replace('<% swaggerOptions %>', stringify(initOptions))
@@ -93,7 +96,8 @@ var serveFiles = function (swaggerDoc, opts) {
   var initOptions = {
     swaggerDoc: swaggerDoc || undefined,
     customOptions: opts.swaggerOptions || {},
-    swaggerUrl: opts.swaggerUrl || {}
+    swaggerUrl: opts.swaggerUrl || {},
+    swaggerUrls: opts.swaggerUrls || undefined
   }
   var swaggerInitWithOpts = swaggerInitFunction(swaggerDoc, initOptions)
   return [swaggerInitWithOpts, swaggerAssetMiddleware()]

--- a/swagger-ui-init.js
+++ b/swagger-ui-init.js
@@ -1,4 +1,3 @@
-
 window.onload = function() {
   // Build a system
   var url = window.location.search.match(/url=([^&]+)/);
@@ -9,11 +8,13 @@ window.onload = function() {
   }
   <% swaggerOptions %>
   url = options.swaggerUrl || url
+  var urls = options.swaggerUrls
   var customOptions = options.customOptions
   var spec1 = options.swaggerDoc
   var swaggerOptions = {
     spec: spec1,
     url: url,
+    urls: urls,
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Support for parameter `urls` of the `sqagger-ui` library was added.
Usage example

```
app.use(
    "/api-docs",
    swaggerUi.serve,
    swaggerUi.setup(undefined, {
      swaggerUrls: [
        { url: "pathToFirstDocument", name: "FirstDocument" },
        { url: "pathToSecondDocument", name: "SecondDocument" }
      ]
    })
  );
```