### PR TITLE
enable to access multiple swagger instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,10 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
 }
 
 var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-    var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-    return function (req, res) { res.send(htmlWithOptions) };
+    return function (req, res) {
+      let htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle);
+      res.send(htmlWithOptions);
+    }
 };
 
 function swaggerInitFn (req, res, next) {


### PR DESCRIPTION
Hi, I provide fix for #92 
This PR enables to access multiple swagger path.
However, it's not possible yet to generate HTML at runtime.
I think that should be treated seperate from this issue.
Thanks.