### PR TITLE
Allow multiple instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,131 +4,136 @@ var fs = require('fs');
 var express = require('express');
 var swaggerUi = require('swagger-ui-dist')
 
-var favIconHtml = '<link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />' +
-                  '<link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />'
+function SwaggerUIExpress() {
 
-var swaggerInit
+  var favIconHtml = '<link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />' +
+                    '<link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />'
 
-var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-  var isExplorer
-  var customJs
-  var swaggerUrls
-  var customCssUrl
-  if (opts && typeof opts === 'object') {
-    options = opts.swaggerOptions
-    customCss = opts.customCss
-    customJs = opts.customJs
-    customfavIcon = opts.customfavIcon
-    swaggerUrl = opts.swaggerUrl
-    swaggerUrls = opts.swaggerUrls
-    isExplorer = opts.explorer || !!swaggerUrls
-    customeSiteTitle = opts.customSiteTitle,
-    customCssUrl = opts.customCssUrl
-  } else {
-    //support legacy params based function
-    isExplorer = opts
-  }
-	options = options || {};
-  var explorerString = isExplorer ? '' : '.swagger-ui .topbar .download-url-wrapper { display: none }';
-    customCss = explorerString + ' ' + customCss || explorerString;
-    customfavIcon = customfavIcon || false;
-    customeSiteTitle = customeSiteTitle || 'Swagger UI';
-	var html = fs.readFileSync(__dirname + '/indexTemplate.html.tpl');
-    try {
-    	fs.unlinkSync(__dirname + '/index.html');
-    } catch (e) {
+  var swaggerInit
 
+  var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
+    var isExplorer
+    var customJs
+    var swaggerUrls
+    var customCssUrl
+    if (opts && typeof opts === 'object') {
+      options = opts.swaggerOptions
+      customCss = opts.customCss
+      customJs = opts.customJs
+      customfavIcon = opts.customfavIcon
+      swaggerUrl = opts.swaggerUrl
+      swaggerUrls = opts.swaggerUrls
+      isExplorer = opts.explorer || !!swaggerUrls
+      customeSiteTitle = opts.customSiteTitle,
+      customCssUrl = opts.customCssUrl
+    } else {
+      //support legacy params based function
+      isExplorer = opts
     }
+  	options = options || {};
+    var explorerString = isExplorer ? '' : '.swagger-ui .topbar .download-url-wrapper { display: none }';
+      customCss = explorerString + ' ' + customCss || explorerString;
+      customfavIcon = customfavIcon || false;
+      customeSiteTitle = customeSiteTitle || 'Swagger UI';
+  	var html = fs.readFileSync(__dirname + '/indexTemplate.html.tpl');
+      try {
+      	fs.unlinkSync(__dirname + '/index.html');
+      } catch (e) {
 
-    var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml;
-    var htmlWithCustomCss = html.toString().replace('<% customCss %>', customCss);
-    var htmlWithFavIcon = htmlWithCustomCss.replace('<% favIconString %>', favIconString);
-    var htmlWithCustomJs = htmlWithFavIcon.replace('<% customJs %>', customJs ? `<script src="${customJs}"></script>` : '');
-    var htmlWithCustomCssUrl = htmlWithCustomJs.replace('<% customCssUrl %>', customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : '');
+      }
 
-    var initOptions = {
-      swaggerDoc: swaggerDoc || undefined,
-      customOptions: options,
-      swaggerUrl: swaggerUrl || undefined,
-      swaggerUrls: swaggerUrls || undefined
-    }
-    var js = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl');
-    swaggerInit = js.toString().replace('<% swaggerOptions %>', stringify(initOptions))
-    return htmlWithCustomCssUrl.replace('<% title %>', customeSiteTitle)
-}
+      var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml;
+      var htmlWithCustomCss = html.toString().replace('<% customCss %>', customCss);
+      var htmlWithFavIcon = htmlWithCustomCss.replace('<% favIconString %>', favIconString);
+      var htmlWithCustomJs = htmlWithFavIcon.replace('<% customJs %>', customJs ? `<script src="${customJs}"></script>` : '');
+      var htmlWithCustomCssUrl = htmlWithCustomJs.replace('<% customCssUrl %>', customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : '');
 
-var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-    var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-    return function (req, res) { res.send(htmlWithOptions) };
-};
-
-function swaggerInitFn (req, res, next) {
-  if (req.url === '/swagger-ui-init.js') {
-    res.set('Content-Type', 'application/javascript')
-    res.send(swaggerInit)
-  } else {
-    next()
+      var initOptions = {
+        swaggerDoc: swaggerDoc || undefined,
+        customOptions: options,
+        swaggerUrl: swaggerUrl || undefined,
+        swaggerUrls: swaggerUrls || undefined
+      }
+      var js = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl');
+      swaggerInit = js.toString().replace('<% swaggerOptions %>', stringify(initOptions))
+      return htmlWithCustomCssUrl.replace('<% title %>', customeSiteTitle)
   }
-}
 
-var swaggerInitFunction = function (swaggerDoc, opts) {
-  var js = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl');
-  var swaggerInitFile = js.toString().replace('<% swaggerOptions %>', stringify(opts))
-  return function (req, res, next) {
+  var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
+      var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
+      return function (req, res) { res.send(htmlWithOptions) };
+  };
+
+  function swaggerInitFn (req, res, next) {
     if (req.url === '/swagger-ui-init.js') {
       res.set('Content-Type', 'application/javascript')
-      res.send(swaggerInitFile)
+      res.send(swaggerInit)
     } else {
       next()
     }
   }
-}
 
-function endsWith(origin, target) {
-  origin.substr(target.length * -1) === target
-}
-
-var swaggerAssetMiddleware = options => {
-  var opts = options || {}
-  opts.index = false
-  return express.static(swaggerUi.getAbsoluteFSPath(), opts)
-}
-
-var serveFiles = function (swaggerDoc, opts) {
-  opts = opts || {}
-  var initOptions = {
-    swaggerDoc: swaggerDoc || undefined,
-    customOptions: opts.swaggerOptions || {},
-    swaggerUrl: opts.swaggerUrl || {},
-    swaggerUrls: opts.swaggerUrls || undefined
-  }
-  var swaggerInitWithOpts = swaggerInitFunction(swaggerDoc, initOptions)
-  return [swaggerInitWithOpts, swaggerAssetMiddleware()]
-}
-
-var serve = [swaggerInitFn, swaggerAssetMiddleware()];
-var serveWithOptions = options => [swaggerInitFn, swaggerAssetMiddleware(options)];
-
-var stringify = function (obj, prop) {
-  var placeholder = '____FUNCTIONPLACEHOLDER____';
-  var fns = [];
-  var json = JSON.stringify(obj, function (key, value) {
-    if (typeof value === 'function') {
-      fns.push(value);
-      return placeholder;
+  var swaggerInitFunction = function (swaggerDoc, opts) {
+    var js = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl');
+    var swaggerInitFile = js.toString().replace('<% swaggerOptions %>', stringify(opts))
+    return function (req, res, next) {
+      if (req.url === '/swagger-ui-init.js') {
+        res.set('Content-Type', 'application/javascript')
+        res.send(swaggerInitFile)
+      } else {
+        next()
+      }
     }
-    return value;
-  }, 2);
-  json = json.replace(new RegExp('"' + placeholder + '"', 'g'), function (_) {
-    return fns.shift();
-  });
-  return 'var options = ' + json + ';';
-};
+  }
 
-module.exports = {
-	setup: setup,
-	serve: serve,
-  serveWithOptions: serveWithOptions,
-  generateHTML: generateHTML,
-  serveFiles: serveFiles
-};
+  function endsWith(origin, target) {
+    origin.substr(target.length * -1) === target
+  }
+
+  var swaggerAssetMiddleware = options => {
+    var opts = options || {}
+    opts.index = false
+    return express.static(swaggerUi.getAbsoluteFSPath(), opts)
+  }
+
+  var serveFiles = function (swaggerDoc, opts) {
+    opts = opts || {}
+    var initOptions = {
+      swaggerDoc: swaggerDoc || undefined,
+      customOptions: opts.swaggerOptions || {},
+      swaggerUrl: opts.swaggerUrl || {},
+      swaggerUrls: opts.swaggerUrls || undefined
+    }
+    var swaggerInitWithOpts = swaggerInitFunction(swaggerDoc, initOptions)
+    return [swaggerInitWithOpts, swaggerAssetMiddleware()]
+  }
+
+  var serve = [swaggerInitFn, swaggerAssetMiddleware()];
+  var serveWithOptions = options => [swaggerInitFn, swaggerAssetMiddleware(options)];
+
+  var stringify = function (obj, prop) {
+    var placeholder = '____FUNCTIONPLACEHOLDER____';
+    var fns = [];
+    var json = JSON.stringify(obj, function (key, value) {
+      if (typeof value === 'function') {
+        fns.push(value);
+        return placeholder;
+      }
+      return value;
+    }, 2);
+    json = json.replace(new RegExp('"' + placeholder + '"', 'g'), function (_) {
+      return fns.shift();
+    });
+    return 'var options = ' + json + ';';
+  };
+
+  return {
+  	setup: setup,
+  	serve: serve,
+    serveWithOptions: serveWithOptions,
+    generateHTML: generateHTML,
+    serveFiles: serveFiles
+  };
+}
+
+module.exports = SwaggerUIExpress

--- a/test/testapp/app.js
+++ b/test/testapp/app.js
@@ -1,6 +1,6 @@
 var express = require('express');
 var app = express();
-var swaggerUi = require('../../index');
+var swaggerUi = require('../../index')();
 var swaggerDocument = require('./swagger.json');
 
 var swaggerDocumentSplit = require('./swagger-split.json');


### PR DESCRIPTION
I wanted to be able to create multiple instances of the swagger ui template to run on the same server. This changes the API, so that might not be desirable, I am ok to just use my fork, but the change makes it so you can accomplish something like this:

```js
const fs = require('fs')
const express = require('express')
const swaggerUI = require('swagger-ui-express')
const swaggerParser = require('swagger-parser')
const util = require('util')

const app = express()

const port = process.env.PORT || 4000

const apis = [
  { yaml: '../some/project/swagger-config.yaml', route: '/docs1' },
  { yaml: '../another/project/swagger-config.yaml', route: '/docs2' }
]

const run = async () => {
  for (let i = 0; i < apis.length; i++) {
    let sui = new swaggerUI()
    let apiSpec = await swaggerParser.bundle(apis[i].yaml)
    console.log(`Using ${apis[i].route} for ${apis[i].yaml}`)
    app.use(apis[i].route, sui.serve, sui.setup(apiSpec))
  }

  app.listen(port, err => {
    if (err) throw err
    console.log(`Listening on port ${port}`)
  })
}

run()
```