### PR TITLE
Correct main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swagger-ui-express",
   "version": "4.0.6",
   "description": "Swagger UI Express",
-  "main": "./lib/index.js",
+  "main": "./index.js",
   "files": [
     "package.json",
     "index.js",


### PR DESCRIPTION
Small issue when using node v12 with "--experimental-modules" and "--es-module-specifier-resolution=node" flags because package.json refers to non-existing file.
See https://github.com/kroonprins/swagger-ui-express-test for example of the error.