### PR TITLE
Optionally pass the swagger doc into the req object

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,24 @@ const swaggerDocument = YAML.load('./swagger.yaml');
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 ```
 
+
+### Modify swagger file on the fly before load
+
+To dynamically set the host in the swagger file based on the incoming request object you may pass the json via the req object; just do not pass the the swagger json to the setup function.
+
+```javascript
+const express = require('express');
+const app = express();
+const swaggerUi = require('swagger-ui-express');
+app.use('/api-docs', function(req, res, next){
+    const swaggerDocument = require('./swagger.json');
+    swaggerDocument.host = req.get('host');
+    req.swaggerDocument = swaggerDocument;
+    next();
+}, swaggerUi.serve, swaggerUi.setup());
+```
+
+
 ## Requirements
 
 * Node v0.10.32 or above

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 ### Modify swagger file on the fly before load
 
-To dynamically set the host in the swagger file based on the incoming request object you may pass the json via the req object; just do not pass the the swagger json to the setup function.
+To dynamically set the host, or any other content, in the swagger file based on the incoming request object you may pass the json via the req object; to achieve this just do not pass the the swagger json to the setup function and it will look for `swaggerDoc` in the `req` object.
 
 ```javascript
 const express = require('express');

--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ To dynamically set the host, or any other content, in the swagger file based on 
 const express = require('express');
 const app = express();
 const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./swagger.json');
+
 app.use('/api-docs', function(req, res, next){
-    const swaggerDocument = require('./swagger.json');
     swaggerDocument.host = req.get('host');
     req.swaggerDoc = swaggerDoc;
     next();

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ const swaggerUi = require('swagger-ui-express');
 app.use('/api-docs', function(req, res, next){
     const swaggerDocument = require('./swagger.json');
     swaggerDocument.host = req.get('host');
-    req.swaggerDocument = swaggerDocument;
+    req.swaggerDoc = swaggerDoc;
     next();
 }, swaggerUi.serve, swaggerUi.setup());
 ```

--- a/index.js
+++ b/index.js
@@ -58,8 +58,12 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
 }
 
 var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-    var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-    return function (req, res) { res.send(htmlWithOptions) };
+    return function (req, res) {
+      swaggerDoc = swaggerDoc || req.swaggerDoc
+      res.send(
+        generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
+      )
+    };
 };
 
 function swaggerInitFn (req, res, next) {

--- a/index.js
+++ b/index.js
@@ -58,12 +58,16 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
 }
 
 var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-    return function (req, res) {
-      swaggerDoc = swaggerDoc || req.swaggerDoc
-      res.send(
-        generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-      )
-    };
+    if(!swaggerDoc){
+      return function (req, res) {
+        res.send(
+          generateHTML(req.swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
+        )
+      };
+    } else {
+      var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
+      return function (req, res) { res.send(htmlWithOptions) };
+    }
 };
 
 function swaggerInitFn (req, res, next) {

--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 'use strict'
 
-var fs = require('fs');
-var express = require('express');
+var fs = require('fs')
+var express = require('express')
 var swaggerUi = require('swagger-ui-dist')
+var htmlTplString = fs.readFileSync(__dirname + '/indexTemplate.html.tpl')
+var jsTplString = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl')
 
 var favIconHtml = '<link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />' +
-                  '<link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />'
+  '<link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />'
 
-var swaggerInit
+var swaggerInit = ''
 
-var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
+var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString) {
   var isExplorer
   var customJs
   var swaggerUrls
@@ -22,55 +24,47 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
     swaggerUrl = opts.swaggerUrl
     swaggerUrls = opts.swaggerUrls
     isExplorer = opts.explorer || !!swaggerUrls
-    customeSiteTitle = opts.customSiteTitle,
+    customeSiteTitle = opts.customSiteTitle
     customCssUrl = opts.customCssUrl
   } else {
     //support legacy params based function
     isExplorer = opts
   }
-	options = options || {};
-  var explorerString = isExplorer ? '' : '.swagger-ui .topbar .download-url-wrapper { display: none }';
-    customCss = explorerString + ' ' + customCss || explorerString;
-    customfavIcon = customfavIcon || false;
-    customeSiteTitle = customeSiteTitle || 'Swagger UI';
-	var html = fs.readFileSync(__dirname + '/indexTemplate.html.tpl');
-    try {
-    	fs.unlinkSync(__dirname + '/index.html');
-    } catch (e) {
+  options = options || {}
+  var explorerString = isExplorer ? '' : '.swagger-ui .topbar .download-url-wrapper { display: none }'
+  customCss = explorerString + ' ' + customCss || explorerString
+  customfavIcon = customfavIcon || false
+  customeSiteTitle = customeSiteTitle || 'Swagger UI'
+  fs.unlink(__dirname + '/index.html', function(err) {
+    console.error(err)
+  })
 
-    }
+  var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml
+  var htmlWithCustomCss = htmlTplString.toString().replace('<% customCss %>', customCss)
+  var htmlWithFavIcon = htmlWithCustomCss.replace('<% favIconString %>', favIconString)
+  var htmlWithCustomJs = htmlWithFavIcon.replace('<% customJs %>', customJs ? `<script src="${customJs}"></script>` : '')
+  var htmlWithCustomCssUrl = htmlWithCustomJs.replace('<% customCssUrl %>', customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : '')
 
-    var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml;
-    var htmlWithCustomCss = html.toString().replace('<% customCss %>', customCss);
-    var htmlWithFavIcon = htmlWithCustomCss.replace('<% favIconString %>', favIconString);
-    var htmlWithCustomJs = htmlWithFavIcon.replace('<% customJs %>', customJs ? `<script src="${customJs}"></script>` : '');
-    var htmlWithCustomCssUrl = htmlWithCustomJs.replace('<% customCssUrl %>', customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : '');
+  var initOptions = {
+    swaggerDoc: swaggerDoc || undefined,
+    customOptions: options,
+    swaggerUrl: swaggerUrl || undefined,
+    swaggerUrls: swaggerUrls || undefined
+  }
 
-    var initOptions = {
-      swaggerDoc: swaggerDoc || undefined,
-      customOptions: options,
-      swaggerUrl: swaggerUrl || undefined,
-      swaggerUrls: swaggerUrls || undefined
-    }
-    var js = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl');
-    swaggerInit = js.toString().replace('<% swaggerOptions %>', stringify(initOptions))
-    return htmlWithCustomCssUrl.replace('<% title %>', customeSiteTitle)
+  swaggerInit = jsTplString.toString().replace('<% swaggerOptions %>', stringify(initOptions))
+  return htmlWithCustomCssUrl.replace('<% title %>', customeSiteTitle)
 }
 
 var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
-    if(!swaggerDoc){
-      return function (req, res) {
-        res.send(
-          generateHTML(req.swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-        )
-      };
-    } else {
-      var htmlWithOptions = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle)
-      return function (req, res) { res.send(htmlWithOptions) };
-    }
-};
+  return function (req, res) {
+    res.send(
+      generateHTML(swaggerDoc || req.swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString)
+    )
+  }
+}
 
-function swaggerInitFn (req, res, next) {
+var swaggerInitFn = function (req, res, next) {
   if (req.url === '/swagger-ui-init.js') {
     res.set('Content-Type', 'application/javascript')
     res.send(swaggerInit)
@@ -80,8 +74,7 @@ function swaggerInitFn (req, res, next) {
 }
 
 var swaggerInitFunction = function (swaggerDoc, opts) {
-  var js = fs.readFileSync(__dirname + '/swagger-ui-init.js.tpl');
-  var swaggerInitFile = js.toString().replace('<% swaggerOptions %>', stringify(opts))
+  var swaggerInitFile = jsTplString.toString().replace('<% swaggerOptions %>', stringify(opts))
   return function (req, res, next) {
     if (req.url === '/swagger-ui-init.js') {
       res.set('Content-Type', 'application/javascript')
@@ -90,10 +83,6 @@ var swaggerInitFunction = function (swaggerDoc, opts) {
       next()
     }
   }
-}
-
-function endsWith(origin, target) {
-  origin.substr(target.length * -1) === target
 }
 
 var swaggerAssetMiddleware = options => {
@@ -114,29 +103,29 @@ var serveFiles = function (swaggerDoc, opts) {
   return [swaggerInitWithOpts, swaggerAssetMiddleware()]
 }
 
-var serve = [swaggerInitFn, swaggerAssetMiddleware()];
-var serveWithOptions = options => [swaggerInitFn, swaggerAssetMiddleware(options)];
+var serve = [swaggerInitFn, swaggerAssetMiddleware()]
+var serveWithOptions = options => [swaggerInitFn, swaggerAssetMiddleware(options)]
 
 var stringify = function (obj, prop) {
-  var placeholder = '____FUNCTIONPLACEHOLDER____';
-  var fns = [];
+  var placeholder = '____FUNCTIONPLACEHOLDER____'
+  var fns = []
   var json = JSON.stringify(obj, function (key, value) {
     if (typeof value === 'function') {
-      fns.push(value);
-      return placeholder;
+      fns.push(value)
+      return placeholder
     }
-    return value;
-  }, 2);
+    return value
+  }, 2)
   json = json.replace(new RegExp('"' + placeholder + '"', 'g'), function (_) {
-    return fns.shift();
-  });
-  return 'var options = ' + json + ';';
-};
+    return fns.shift()
+  })
+  return 'var options = ' + json + ';'
+}
 
 module.exports = {
-	setup: setup,
-	serve: serve,
+  setup: setup,
+  serve: serve,
   serveWithOptions: serveWithOptions,
   generateHTML: generateHTML,
   serveFiles: serveFiles
-};
+}

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
   customCss = explorerString + ' ' + customCss || explorerString
   customfavIcon = customfavIcon || false
   customeSiteTitle = customeSiteTitle || 'Swagger UI'
-  fs.unlink(__dirname + '/index.html', function(err) {
+  fs.unlink(__dirname + '/index.html', function (err) {
     console.error(err)
   })
 
@@ -57,10 +57,9 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
 }
 
 var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle) {
+  var html = generateHTML(swaggerDoc || req.swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString)
   return function (req, res) {
-    res.send(
-      generateHTML(swaggerDoc || req.swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString)
-    )
+    res.send(html)
   }
 }
 


### PR DESCRIPTION
During development we work with many micro-services. in swagger 2 you can only have a single host which poses a problem during development and the developers was to use the swagger to test their api.

This pr injects the swagger doc into the req object and thus allowing the dev to inject an additional middleware into the mix.. in the readme (and the one I use from the fork), I can modify the swagger host based on the express host within the request object. This dynamically sets the host based on the env the ap is running, local -> dev -> int etc etc.