### PR TITLE
Fix request swagger document not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ const swaggerDocument = require('./swagger.json');
 
 app.use('/api-docs', function(req, res, next){
     swaggerDocument.host = req.get('host');
-    req.swaggerDoc = swaggerDoc;
+    req.swaggerDoc = swaggerDocument;
     next();
 }, swaggerUi.serve, swaggerUi.setup());
 ```

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swagg
   var html = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString)
   return function (req, res) {
     if (req.swaggerDoc) {
-      var reqHtml = generateHTML(swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString)
+      var reqHtml = generateHTML(req.swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customeSiteTitle, htmlTplString, jsTplString)
       res.send(reqHtml)
     } else {
       res.send(html)


### PR DESCRIPTION
## Why

I couldn't get the dynamic hostname feature introduced in #142 to work. Looking into the history of the repository I found that https://github.com/scottie1984/swagger-ui-express/commit/d10791ba2f248ecff1fffdc2d4c3a6f2cdc4896d is the reason why. This fix is using the old `swaggerDoc`, instead of the one provided by the request.

## What

* Use the correct `swaggerDoc` when one is provided in the request
* Fix the example in the readme as it's referring to a non-existing variable.