### PR TITLE
fix: name middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swagg
   }
 }
 
-var swaggerInitFn = function (req, res, next) {
+function swaggerInitFn(req, res, next) {
   if (req.url === '/swagger-ui-init.js') {
     res.set('Content-Type', 'application/javascript')
     res.send(swaggerInit)


### PR DESCRIPTION
Refactor function assignment to function expression in middleware in order to track function calls in monitor services like [NewRelic](https://newrelic.com/).
Otherwise `Middleware <anonymous>` is shown in the dashboard.