### PR TITLE
Url checking improved

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,9 +198,9 @@ var setup = function (swaggerDoc, opts, options, customCss, customfavIcon, swagg
 }
 
 function swaggerInitFn(req, res, next) {
-  if (trimQuery(req.url) === '/package.json') {
+  if (trimQuery(req.url).endsWith('/package.json')) {
     res.sendStatus(404)
-  } else if (trimQuery(req.url) === '/swagger-ui-init.js') {
+  } else if (trimQuery(req.url).endsWith('/swagger-ui-init.js')) {
     res.set('Content-Type', 'application/javascript')
     res.send(swaggerInit)
   } else {
@@ -211,9 +211,9 @@ function swaggerInitFn(req, res, next) {
 var swaggerInitFunction = function (swaggerDoc, opts) {
   var swaggerInitFile = jsTplString.toString().replace('<% swaggerOptions %>', stringify(opts))
   return function (req, res, next) {
-    if (trimQuery(req.url) === '/package.json') {
+    if (trimQuery(req.url).endsWith('/package.json')) {
       res.sendStatus(404)
-    } else if (trimQuery(req.url) === '/swagger-ui-init.js') {
+    } else if (trimQuery(req.url).endsWith('/swagger-ui-init.js')) {
       if (req.swaggerDoc) {
         swaggerInitFile = jsTplString.toString().replace('<% swaggerOptions %>', stringify(opts))
       }


### PR DESCRIPTION
swagger-ui-init.js and package.json are compared with endsWith now.
Reason: While using Nest.Js + azure function http adapter, the url contains the hostname and the check with === does not work