### PR TITLE
Accept multiple Javascript and CSS imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,28 @@ window.onload = function() {
 }
 `
 
+function toExternalScriptTag(url) {
+  return `<script src='${url}'></script>`
+}
+
+function toInlineScriptTag(jsCode) {
+  return `<script>${jsCode}</script>`
+}
+
+function toExternalStylesheetTag(url) {
+  return `<link href='${url}' rel='stylesheet'>`
+}
+
+function toTags(customCode, toScript) {
+  if (typeof customCode === 'string') {
+    return toScript(customCode)
+  } else if (Array.isArray(customCode)) {
+    return customCode.map(toScript).join('\n')
+  } else {
+    return ''
+  }
+}
+
 var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon, swaggerUrl, customSiteTitle, _htmlTplString, _jsTplString) {
   var isExplorer
   var customJs
@@ -170,9 +192,9 @@ var generateHTML = function (swaggerDoc, opts, options, customCss, customfavIcon
   var favIconString = customfavIcon ? '<link rel="icon" href="' + customfavIcon + '" />' : favIconHtml
   var htmlWithCustomCss = _htmlTplString.toString().replace('<% customCss %>', customCss)
   var htmlWithFavIcon = htmlWithCustomCss.replace('<% favIconString %>', favIconString)
-  var htmlWithCustomJsUrl = htmlWithFavIcon.replace('<% customJs %>', customJs ? `<script src="${customJs}"></script>` : '')
-  var htmlWithCustomJs = htmlWithCustomJsUrl.replace('<% customJsStr %>', customJsStr ? `<script>${customJsStr}</script>` : '')
-  var htmlWithCustomCssUrl = htmlWithCustomJs.replace('<% customCssUrl %>', customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : '')
+  var htmlWithCustomJsUrl = htmlWithFavIcon.replace('<% customJs %>', toTags(customJs, toExternalScriptTag))
+  var htmlWithCustomJs = htmlWithCustomJsUrl.replace('<% customJsStr %>', toTags(customJsStr, toInlineScriptTag))
+  var htmlWithCustomCssUrl = htmlWithCustomJs.replace('<% customCssUrl %>', toTags(customCssUrl, toExternalStylesheetTag))
 
   var initOptions = {
     swaggerDoc: swaggerDoc || undefined,


### PR DESCRIPTION
For integrating a Swagger plugin I need to be able to include external Javascript.
This works for exactly one because the opts parameter accepts exactly one URL for external Javascript via the customJs property.
If I want to use a second Swagger plugin or want to include other Javascript code there is no direct way without "hacking".

This PR removes the constraint to only being able to import one external script, one external css and one inline script by accepting strings and arrays for the customJs, customJsStr and customCssUrl parameter.