### PR TITLE
Support for preauthorizeApiKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,11 @@ window.onload = function() {
     const key = customOptions.preauthorizeApiKey.authDefinitionKey;
     const value = customOptions.preauthorizeApiKey.apiKeyValue;
     if (!!key && !!value) {
-      ui.preauthorizeBasic(key, value);
+      const pid = setInterval(() => {
+        const authorized = ui.preauthorizeApiKey(key, value);
+        if(!!authorized) clearInterval(pid);
+      }, 500)
+      
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -130,6 +130,14 @@ window.onload = function() {
     ui.initOAuth(customOptions.oauth)
   }
 
+  if (customOptions.preauthorizeApiKey) {
+    const key = customOptions.preauthorizeApiKey.authDefinitionKey;
+    const value = customOptions.preauthorizeApiKey.apiKeyValue;
+    if (!!key && !!value) {
+      ui.preauthorizeBasic(key, value);
+    }
+  }
+
   if (customOptions.authAction) {
     ui.authActions.authorize(customOptions.authAction)
   }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   },
   "devDependencies": {
     "es6-shim": "0.35.2",
-    "express": "4.12.2",
+    "express": "^4.18.2",
     "istanbul-badges-readme": "^1.2.0",
-    "mocha": "2.2.5",
+    "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "puppeteer": "5.3.1"
   },

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -51,7 +51,6 @@ describe('integration', function() {
     assert.equal('Swagger UI', await sitepage.title());
     const html = await sitepage.evaluate(() => document.querySelector('.swagger-ui').innerHTML);
     assert.ok(html);
-// console.log(`**** ${html}`);
     assert.notEqual(html.indexOf("id=\"operations-\\/test-index\""), -1);
     assert.notEqual(html.indexOf("id=\"operations-\\/test-impossible\""), -1);
   });
@@ -59,6 +58,13 @@ describe('integration', function() {
   it('should have API Documentation hosted at /api-docs-using-object', async function() {
     const httpResponse = await sitepage.goto('http://localhost:3001/api-docs-using-object/');
     assert.ok(httpResponse.ok());
+  });
+
+  it('should have preauthorized api key', async function() {
+    await sitepage.waitForSelector('.auth-wrapper > .btn.authorize.locked', { timeout: 0 });
+    const classes = await sitepage.evaluate(() => Array.from(document.querySelector('.auth-wrapper > .btn.authorize.locked').classList));
+    assert(classes.includes('locked'));
+    assert(!classes.includes('unlocked'));
   });
 
   it('should contain the expected elements on the page for api-docs-using-object', async function() {
@@ -89,4 +95,29 @@ describe('integration', function() {
     const body = await sitepage.evaluate(() => document.querySelector('body').innerText);
     assert.equal('Not Found', body);
   });
+
+  it('should should have API Documentation hosted at /api-docs-with-url-in-swaggerOptions', async function() {
+    const httpResponse = await sitepage.goto('http://localhost:3001/api-docs-with-url-in-swaggerOptions/');
+    assert.ok(httpResponse.ok());
+  });
+
+  it('should not have preauthorized api key', async function() {
+    await sitepage.waitForSelector('.auth-wrapper > .btn.authorize.unlocked', { timeout: 0 });
+    const classes = await sitepage.evaluate(() => Array.from(document.querySelector('.auth-wrapper > .btn.authorize.unlocked').classList));
+    assert(!classes.includes('locked'));
+    assert(classes.includes('unlocked'));
+  });
+
+  it('should should have API Documentation hosted at /api-docs-with-url-in-swaggerOptions-preauthorized', async function() {
+    const httpResponse = await sitepage.goto('http://localhost:3001/api-docs-with-url-in-swaggerOptions-preauthorized/');
+    assert.ok(httpResponse.ok());
+  });
+
+  it('should have preauthorized api key', async function() {
+    await sitepage.waitForSelector('.auth-wrapper > .btn.authorize.locked', { timeout: 0 });
+    const classes = await sitepage.evaluate(() => Array.from(document.querySelector('.auth-wrapper > .btn.authorize.locked').classList));
+    assert(classes.includes('locked'));
+    assert(!classes.includes('unlocked'));
+  });
+
 });

--- a/test/testapp/app.js
+++ b/test/testapp/app.js
@@ -18,6 +18,10 @@ app.use((req, res, next) => {
 });
 
 var options = {
+	preauthorizeApiKey: {
+	 authDefinitionKey: 'api_key',
+	 apiKeyValue: 'Bearer XYZ'
+	},
 	validatorUrl : null,
 	oauth: {
 	 clientId: "your-client-id1",
@@ -117,8 +121,32 @@ app.get('/api-docs-jsstr', swaggerUi.setup(null, swaggerUiOpts3));
 //     next();
 // }, swaggerUi.serveFiles(swaggerDocument, options), swaggerUi.setup());
 
+var swaggerUiOpts4 = {
+	swaggerOptions: {
+		url: 'http://localhost:' + (app.get('port') || 3001) + '/swagger.json'
+	}
+}
+
+app.use('/api-docs-with-url-in-swaggerOptions', swaggerUi.serve)
+app.get('/api-docs-with-url-in-swaggerOptions', swaggerUi.setup(null, swaggerUiOpts4));
+
+
+var swaggerUiOpts5 = {
+	swaggerOptions: {
+		url: 'http://localhost:' + (app.get('port') || 3001) + '/swagger.json',
+		preauthorizeApiKey: {
+			authDefinitionKey: 'api_key',
+			apiKeyValue: 'Bearer XYZ'
+		   }
+	}
+}
+
+app.use('/api-docs-with-url-in-swaggerOptions-preauthorized', swaggerUi.serve)
+app.get('/api-docs-with-url-in-swaggerOptions-preauthorized', swaggerUi.setup(null, swaggerUiOpts5));
+
+
 app.use(function(req, res) {
-    res.send(404, 'Page not found');
+    res.status(404).send('Page not found');
 });
 
 module.exports = app;

--- a/test/testapp/swagger.json
+++ b/test/testapp/swagger.json
@@ -37,5 +37,12 @@
 		  "responses": {}
 		}
 	  }
-   }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in":"header"
+    }
+  }
 }


### PR DESCRIPTION
This PR addresses issue #311. 

The implementation needed a setInterval function call because of the unpredictable time that takes for the preauthorizeApiKey function to load schema definition.

Added proper unit testing as well