### PR TITLE
Fix `serveFiles` to work w/ dynamic swaggerDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ var options = {}
 app.use('/api-docs-one', swaggerUi.serveFiles(swaggerDocumentOne, options), swaggerUi.setup(swaggerDocumentOne));
 
 app.use('/api-docs-two', swaggerUi.serveFiles(swaggerDocumentTwo, options), swaggerUi.setup(swaggerDocumentTwo));
+
+app.use('/api-docs-dynamic', function(req, res, next){
+  req.swaggerDoc = swaggerDocument;
+  next();
+}, swaggerUi.serveFiles(), swaggerUi.setup());
 ```
 
 ### Link to Swagger document

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ window.onload = function() {
         const authorized = ui.preauthorizeApiKey(key, value);
         if(!!authorized) clearInterval(pid);
       }, 500)
-      
+
     }
   }
 
@@ -254,6 +254,7 @@ var swaggerInitFunction = function (swaggerDoc, opts) {
       res.sendStatus(404)
     } else if (trimQuery(req.url).endsWith('/swagger-ui-init.js')) {
       if (req.swaggerDoc) {
+        opts.swaggerDoc = req.swaggerDoc
         swaggerInitFile = jsTplString.toString().replace('<% swaggerOptions %>', stringify(opts))
       }
       res.set('Content-Type', 'application/javascript')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/*",
+    "test": "./node_modules/.bin/mocha test/*.spec.js",
     "coverage:report": "nyc ./node_modules/.bin/mocha test/* || exit 0",
     "coverage:badge": "npm run coverage:report && istanbul-badges-readme --coverageDir='./coverage'",
     "test-app": "node ./test/testapp/run.js "

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -120,4 +120,13 @@ describe('integration', function() {
     assert(!classes.includes('unlocked'));
   });
 
+  it('should have API Documentation hosted at /api-docs-dynamic', async function() {
+    const httpResponse = await sitepage.goto('http://localhost:3001/api-docs-dynamic/');
+    assert.ok(httpResponse.ok());
+    const html = await sitepage.evaluate(() => document.querySelector('.swagger-ui').innerHTML);
+    assert.ok(html);
+    console.log(html);
+    assert.match(html, /Hello [\d]+/);
+  });
+
 });

--- a/test/testapp/app.js
+++ b/test/testapp/app.js
@@ -101,6 +101,14 @@ var swaggerHtml = swaggerUi.generateHTML(swaggerDocument, swaggerUiOpts)
 app.use('/api-docs-html1', swaggerUi.serveFiles(swaggerDocument, swaggerUiOpts))
 app.get('/api-docs-html1', (req, res) => { res.send(swaggerHtml) });
 
+let count = 0
+app.use('/api-docs-dynamic', function(req, res, next){
+    count = count + 1
+    swaggerDocument.info.description = `Hello ${count}!`;
+    req.swaggerDoc = swaggerDocument;
+    next();
+}, swaggerUi.serveFiles(), swaggerUi.setup());
+
 var swaggerUiOpts3 = {
 	explorer: false,
 	swaggerOptions: options,
@@ -112,14 +120,6 @@ var swaggerUiOpts3 = {
 
 app.use('/api-docs-jsstr', swaggerUi.serve)
 app.get('/api-docs-jsstr', swaggerUi.setup(null, swaggerUiOpts3));
-
-// let count = 0
-// app.use('/api-docs-dynamic', function(req, res, next){
-// 	count = count + 1
-//     swaggerDocument.info.description = `Hello ${count}!`;
-//     req.swaggerDoc = swaggerDocument;
-//     next();
-// }, swaggerUi.serveFiles(swaggerDocument, options), swaggerUi.setup());
 
 var swaggerUiOpts4 = {
 	swaggerOptions: {


### PR DESCRIPTION
`serveFiles` did not respect on-the-fly changes in a swagger doc,
but rendered the old content.

The fix now also enables this pattern, where `serveFiles` doesn't need
the swaggerDoc upfront (which is desired in dynamic cases):

```js
app.use('/api-docs-dynamic', function(req, res, next){
  swaggerDocument.info.description = `Hello ${count}!`;
  req.swaggerDoc = swaggerDocument;
  next();
}, swaggerUi.serveFiles(), swaggerUi.setup());
//                     ^^^
```

Also fixes #318 which stumbled over the same issue, but draw the wrong
conclusion that the documentation would be wrong.