### PR TITLE
Allow express 5-beta. Fixes #341

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "swagger-ui-dist": ">=4.11.0"
   },
   "peerDependencies": {
-    "express": ">=4.0.0"
+    "express": ">=4.0.0 || >=5.0.0-beta"
   }
 }


### PR DESCRIPTION
Fixes #341

My team has been using swagger-ui-express with express 5 for multiple years with no issues.

After upgrading to npm 9, we started seeing peerDependency failures. This PR fixes them.