### PR TITLE
Update Swagger to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/scottie1984/swagger-ui-express",
   "dependencies": {
-    "swagger-ui-dist": ">=4.11.0"
+    "swagger-ui-dist": ">=5.0.0"
   },
   "peerDependencies": {
     "express": ">=4.0.0 || >=5.0.0-beta"


### PR DESCRIPTION
Very small change of the version number seems to work without issue

All the tests pass and the test app works when opening http://localhost:3001/api-docs

Fixes: #349 