### PR TITLE
Performance Improvment: Only import required function / file of swagger-ui-dist

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var express = require('express')
-var swaggerUi = require('swagger-ui-dist')
+var getAbsoluteSwaggerFsPath = require('swagger-ui-dist/absolute-path')
 var favIconHtml = '<link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />' +
   '<link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />'
 var swaggerInit = ''
@@ -268,7 +268,7 @@ var swaggerInitFunction = function (swaggerDoc, opts) {
 var swaggerAssetMiddleware = options => {
   var opts = options || {}
   opts.index = false
-  return express.static(swaggerUi.getAbsoluteFSPath(), opts)
+  return express.static(getAbsoluteSwaggerFsPath(), opts)
 }
 
 var serveFiles = function (swaggerDoc, opts) {


### PR DESCRIPTION
This PR updates the import of `swagger-ui-dist` to only load the individual file used to get the path for the static assets, not the code of the static assets themself.
Before the entire dist lib was loaded which contains the entire code, a huge bundle.

I've noticed that in the project I'm working on (https://github.com/juice-shop/juice-shop/) the server takes about 150ms on startup loading the swagger-ui-dist packge.

<img width="1423" alt="Screenshot 2023-06-24 at 22 07 14" src="https://github.com/scottie1984/swagger-ui-express/assets/13718901/402f0c72-1a22-4d18-873f-9cb54d4b6c70">

Chaning his import drastically reduces the amount of code which needs to be loaded on the server side.
For us this means that swagger-ui becomes fast enough to be nearly unmeasurable, improving our total cpu load on start and total server start time by ~10% (`~1.2s -> ~1.1s`)

I've check briefly, from what I saw this should also work nicely with swagger-ui-dist v5.

Thank you for all the work you do here, much appreciated 🙌